### PR TITLE
Upgraded the attrs to version 24.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ exclude = [
 [tool.poetry.dependencies]
 python = ">=3.6.2"
 lxml = "4.9.4"
-attrs = "^21.4.0"
+attrs = "^24.2.0"
 null-object = "^0.1.0"
 pyyaml = "6.0.1"
 


### PR DESCRIPTION
I would like to upgrade the attrs package's version to the latest version (i.e. 24.2.0). There are a lot of packages are pending on attrs v24.2.0. If we keep it on v21.4.0, it will no doubt introduce version conflicts when we try to work both on broadworks_ocip and on other libs in one project.
I run the Unit Tests with the new version of attrs. They all passed.